### PR TITLE
Add marketplace license link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Microsoft DevLabs
+Copyright (c) Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -35,7 +35,7 @@
   },
   "links": {
     "support": {
-      "uri": "https://github.com/microsoft/azure-boards-split"
+      "uri": "https://github.com/microsoft/azure-boards-split/issues"
     },
     "repository": {
       "uri": "https://github.com/microsoft/azure-boards-split"

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -3,7 +3,10 @@
   "id": "vsts-extension-split-work",
   "version": "0.1.20",
   "name": "Split!",
-  "scopes": ["vso.work", "vso.work_write"],
+  "scopes": [
+    "vso.work",
+    "vso.work_write"
+  ],
   "description": "Split a work item to track work that will continue into the next sprint.",
   "publisher": "blueprint",
   "public": true,
@@ -15,10 +18,19 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "tags": ["Split", "Agile", "Sprint", "Iteration", "Scrum"],
+  "tags": [
+    "Split",
+    "Agile",
+    "Sprint",
+    "Iteration",
+    "Scrum"
+  ],
   "content": {
     "details": {
       "path": "details.md"
+    },
+    "license": {
+      "path": "LICENSE"
     }
   },
   "links": {
@@ -42,13 +54,17 @@
       "addressable": true
     }
   ],
-  "categories": ["Azure Boards"],
+  "categories": [
+    "Azure Boards"
+  ],
   "contributions": [
     {
       "id": "vsts-extension-split-work-action",
       "type": "ms.vss-web.action-provider",
       "description": "",
-      "targets": ["ms.vss-work-web.work-item-context-menu"],
+      "targets": [
+        "ms.vss-work-web.work-item-context-menu"
+      ],
       "properties": {
         "group": "contributed",
         "uri": "dist/index.html"


### PR DESCRIPTION
This pull request includes changes to the `LICENSE` file and the `azure-devops-extension.json` file to update copyright information and improve the formatting.

### License Update:
* `LICENSE`: Updated the copyright information from "Microsoft DevLabs" to "Microsoft Corporation." (F22aed37L1)

### JSON Formatting Improvements:
* `azure-devops-extension.json`: Reformatted the `scopes` field to be a multiline array for better readability. (F0024f98L3)
* `azure-devops-extension.json`: Reformatted the `tags` field to be a multiline array for better readability. (F0024f98L15)
* `azure-devops-extension.json`: Added a `license` path under the `content` section to include the license file. (F0024f98L18)
* `azure-devops-extension.json`: Reformatted the `categories` and `targets` fields to be multiline arrays for better readability. (F0024f98L42)