### PR TITLE
Removing Public Flag From Default ExtensionVisibility

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -9,7 +9,6 @@
   ],
   "description": "Split a work item to track work that will continue into the next sprint.",
   "publisher": "blueprint",
-  "public": true,
   "icons": {
     "default": "dist/img/logo.png"
   },


### PR DESCRIPTION
Removing public flag from azure-devops-extension.json file. Whether the extension is public or not, it is being set at https://github.com/microsoft/azure-boards-split/tree/main/configs.

If we keep the existing azure-devops-extension.json file, then it supersedes the configs set for different environments.

Also, the publishing task works differently as compared to the packaging task in terms of extension visibility. The packaging task isn't able to override with the extensionVisibility or override-file parameters.